### PR TITLE
fix(getting-started): assign dedicated Vite port to avoid conflicts during parallel test runs

### DIFF
--- a/examples/getting-started/playwright.config.ts
+++ b/examples/getting-started/playwright.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   reporter: "html",
   timeout: 120000, // 120s per test (S3 loading can be slow)
   use: {
-    baseURL: "http://localhost:5173",
+    baseURL: "http://localhost:5174",
     trace: "on-first-retry",
     // EGL is only available on Linux; macOS/Windows use native GPU
     launchOptions: {
@@ -24,7 +24,7 @@ export default defineConfig({
   ],
   webServer: {
     command: "npm run dev",
-    url: "http://localhost:5173",
+    url: "http://localhost:5174",
     reuseExistingServer: !process.env.CI,
     timeout: 60000,
   },

--- a/examples/getting-started/vite.config.ts
+++ b/examples/getting-started/vite.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from "vite"
 
 export default defineConfig({
   server: {
+    port: 5174,
+    strictPort: true,
     headers: {
       "Cross-Origin-Opener-Policy": "same-origin",
       "Cross-Origin-Embedder-Policy": "require-corp",


### PR DESCRIPTION
## Summary

Assigns a dedicated Vite dev server port to the `examples/getting-started` package so that `pnpm -r test` can run all test suites in parallel without port conflicts.

## Problem

Both `fidnii/` and `examples/getting-started/` had their Playwright configs launching a Vite dev server on **port 5173**. When `pnpm -r test` runs both test suites concurrently, this causes one of two failures depending on startup order:

1. **`fidnii/` starts first** — its `vite.config.ts` uses `strictPort: true`, so it claims port 5173. The getting-started Vite server silently auto-increments to another port, but Playwright still expects 5173 and ends up testing against the **wrong server**.
2. **`getting-started/` starts first** — it claims port 5173, and then `fidnii/`'s Vite **crashes hard** due to `strictPort: true`.

## Changes

| File | Change |
|---|---|
| `examples/getting-started/vite.config.ts` | Added `port: 5174` and `strictPort: true` to the server config |
| `examples/getting-started/playwright.config.ts` | Updated `baseURL` and `webServer.url` from port 5173 to 5174 |

## Port assignments

| Package | Port | `strictPort` |
|---|---|---|
| `fidnii/` | 5173 | `true` (unchanged) |
| `examples/getting-started/` | 5174 | `true` (new) |

Both packages now use `strictPort: true`, so any future conflicts will fail fast with a clear error rather than silently connecting to the wrong server.