### PR TITLE
fix(changeset): remove non-workspace root package from ignore list

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,7 +11,6 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [
-    "@fideus-labs/fidnii-monorepo",
     "@fideus-labs/fidnii-getting-started",
     "@fideus-labs/fidnii-example-convert"
   ]


### PR DESCRIPTION
## Summary

Fixes the Changeset CI validation error by removing `@fideus-labs/fidnii-monorepo` from the `ignore` list in `.changeset/config.json`.

## Problem

The Changeset CI check was failing with a `ValidationError`:

```
The package or glob expression "@fideus-labs/fidnii-monorepo" is specified in the `ignore` option
but it is not found in the project.
```

## Root Cause

The root `package.json` is named `@fideus-labs/fidnii-monorepo`, but it is **not** a pnpm workspace member — `pnpm-workspace.yaml` only includes `fidnii` and `examples/*`. Changesets only recognizes packages that are part of the workspace, so referencing the root package in the `ignore` list causes a validation error.

## Changes

- Removed `@fideus-labs/fidnii-monorepo` from the `ignore` array in `.changeset/config.json`
- The remaining ignore entries (`@fideus-labs/fidnii-getting-started`, `@fideus-labs/fidnii-example-convert`) are valid workspace packages and are unaffected

Since the root package was never visible to changesets in the first place, removing it from the ignore list has no functional side effects — it simply fixes the validation.