### PR TITLE
feat: add loadLevel() API and interactive level selection in convert example

### DIFF
--- a/.changeset/add-load-level.md
+++ b/.changeset/add-load-level.md
@@ -1,0 +1,5 @@
+---
+"@fideus-labs/fidnii": minor
+---
+
+Add public `loadLevel(levelIndex)` method to `OMEZarrNVImage` for loading a specific resolution level, bypassing the automatic `maxPixels`-based selection.

--- a/examples/convert/index.html
+++ b/examples/convert/index.html
@@ -134,6 +134,17 @@
       .mono {
         font-family: monospace;
       }
+      #multiscales-table tbody tr {
+        cursor: pointer;
+        transition: background 0.15s;
+      }
+      #multiscales-table tbody tr:hover {
+        background: var(--wa-color-surface-hover);
+      }
+      #multiscales-table tbody tr.active-level {
+        background: var(--wa-color-primary-100);
+        font-weight: 600;
+      }
       .actions {
         display: flex;
         gap: 0.5rem;

--- a/fidnii/src/OMEZarrNVImage.ts
+++ b/fidnii/src/OMEZarrNVImage.ts
@@ -942,6 +942,27 @@ export class OMEZarrNVImage extends NVImage {
   }
 
   /**
+   * Load a specific resolution level.
+   *
+   * Overrides the automatic `maxPixels`-based level selection and loads the
+   * requested level directly.  The preview step is skipped because the caller
+   * has explicitly chosen a level.
+   *
+   * @param levelIndex - Zero-based resolution level (0 = highest resolution)
+   * @throws If `levelIndex` is out of range
+   */
+  async loadLevel(levelIndex: number): Promise<void> {
+    const numLevels = this.multiscales.images.length
+    if (levelIndex < 0 || levelIndex >= numLevels) {
+      throw new Error(
+        `levelIndex ${levelIndex} out of range [0, ${numLevels - 1}]`,
+      )
+    }
+    this.targetLevelIndex = levelIndex
+    await this.populateVolume(true, "initial")
+  }
+
+  /**
    * Get the volume bounds in world space.
    */
   getVolumeBounds(): VolumeBounds {


### PR DESCRIPTION
Add OMEZarrNVImage.loadLevel(levelIndex) to allow loading a specific
resolution level, bypassing the automatic maxPixels-based selection.

In the convert example, the Multiscales Info table rows now highlight the
currently rendered level and clicking a different row loads that level via
the new API.
