### PR TITLE
feat: add label image support with discrete Glasbey colormap

### DIFF
--- a/.changeset/label-image-support.md
+++ b/.changeset/label-image-support.md
@@ -1,0 +1,5 @@
+---
+"@fideus-labs/fidnii": minor
+---
+
+Add label image support: detect OME-Zarr volumes with `method: "itkwasm_label_image"` and render them with a discrete Glasbey colormap via NiiVue's `setColormapLabel()` instead of a continuous colormap. Re-export `Methods` enum from `@fideus-labs/ngff-zarr`.

--- a/fidnii/src/index.ts
+++ b/fidnii/src/index.ts
@@ -34,6 +34,8 @@
  * ```
  */
 
+// Re-export Methods enum so consumers can check isLabelImage or compare method values
+export { Methods } from "@fideus-labs/ngff-zarr"
 // Worker pool lifecycle (re-exported from ngff-zarr)
 export { terminateWorkerPool } from "@fideus-labs/ngff-zarr/browser"
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "pnpm": {
     "overrides": {
-      "@fideus-labs/ngff-zarr": "^0.7.4",
+      "@fideus-labs/ngff-zarr": "^0.7.5",
       "zarrita": "^0.6.1",
       "@fideus-labs/fizarrita": "^1.2.0",
       "@fideus-labs/worker-pool": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@fideus-labs/ngff-zarr': ^0.7.4
+  '@fideus-labs/ngff-zarr': ^0.7.5
   zarrita: ^0.6.1
   '@fideus-labs/fizarrita': ^1.2.0
   '@fideus-labs/worker-pool': ^1.0.0
@@ -54,8 +54,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0(zarrita@0.6.1)
       '@fideus-labs/ngff-zarr':
-        specifier: ^0.7.4
-        version: 0.7.4
+        specifier: ^0.7.5
+        version: 0.7.5
       '@itk-wasm/image-io':
         specifier: ^1.6.0
         version: 1.6.0
@@ -82,8 +82,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0(@niivue/niivue@0.67.0)
       '@fideus-labs/ngff-zarr':
-        specifier: ^0.7.4
-        version: 0.7.4
+        specifier: ^0.7.5
+        version: 0.7.5
       '@niivue/niivue':
         specifier: ^0.67.0
         version: 0.67.0
@@ -101,8 +101,8 @@ importers:
   fidnii:
     dependencies:
       '@fideus-labs/ngff-zarr':
-        specifier: ^0.7.4
-        version: 0.7.4
+        specifier: ^0.7.5
+        version: 0.7.5
       '@itk-wasm/downsample':
         specifier: ^1.8.1
         version: 1.8.1
@@ -528,8 +528,8 @@ packages:
     peerDependencies:
       zarrita: ^0.6.1
 
-  '@fideus-labs/ngff-zarr@0.7.4':
-    resolution: {integrity: sha512-c9hZmP9HnguELyj4u2J9+eKqQO3mfBMRf0Qe8VcUg/lmrnpX8rmkhuIUfTaymhbFCue5RpJ0+CpdlqnudrS+oQ==}
+  '@fideus-labs/ngff-zarr@0.7.5':
+    resolution: {integrity: sha512-xttOheaC93A0PhPeR1DPUja5yIy6biHwbwfD1bq1mCiT1poitmP+fVR83/97paXJeO51Iigvbe4k7JQnSkc+TA==}
 
   '@fideus-labs/worker-pool@1.0.0':
     resolution: {integrity: sha512-Mwx8fFKKpTUcEtR7w45MQJ/RnZFUPBtefEvGTZGlZMAVSfD7W61rpB8ZdgS4V0CXfppwcb90BF7F/aANWvupnA==}
@@ -2551,7 +2551,7 @@ snapshots:
 
   '@fideus-labs/fidnii@0.1.0(@niivue/niivue@0.67.0)':
     dependencies:
-      '@fideus-labs/ngff-zarr': 0.7.4
+      '@fideus-labs/ngff-zarr': 0.7.5
       '@itk-wasm/downsample': 1.8.1
       '@niivue/niivue': 0.67.0
       gl-matrix: 3.4.4
@@ -2567,7 +2567,7 @@ snapshots:
       '@fideus-labs/worker-pool': 1.0.0
       zarrita: 0.6.1
 
-  '@fideus-labs/ngff-zarr@0.7.4':
+  '@fideus-labs/ngff-zarr@0.7.5':
     dependencies:
       '@fideus-labs/fizarrita': 1.2.0(zarrita@0.6.1)
       '@fideus-labs/worker-pool': 1.0.0


### PR DESCRIPTION
Detect OME-Zarr volumes where multiscales.method is ITKWASM_LABEL_IMAGE
and render them with a discrete Glasbey colormap via setColormapLabel()
instead of continuous colormaps. OMERO intensity windowing is skipped
for label images since it is not applicable to discrete categories.

Library changes:
- Add isLabelImage field to OMEZarrNVImage based on multiscales.method
- Add _applyLabelColormap() using Glasbey palette with transparent bg
- Skip OMERO windowing and cal_range widening for label images
- Re-export Methods enum from @fideus-labs/ngff-zarr

Converter changes:
- Auto-detect label images (integer type + <=64 unique values) and
  override downsampling method to ITKWASM_LABEL_IMAGE when default
- Skip continuous colormap application for label images in preview
