### PR TITLE
ci: configure Changesets release workflow with GitHub Releases and npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release:
@@ -26,6 +27,12 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
+      - name: Upgrade npm (required for trusted publishing)
+        run: npm install -g npm@11.10.0
+
+      - name: Show npm version
+        run: npm --version
+
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm build
@@ -38,6 +45,6 @@ jobs:
           publish: pnpm changeset publish
           title: "chore: version packages"
           commit: "chore: version packages"
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,10 +52,10 @@ importers:
         version: link:../../fidnii
       '@fideus-labs/fiff':
         specifier: ^0.5.2
-        version: 0.5.2(@fideus-labs/ngff-zarr@0.12.0)(@fideus-labs/worker-pool@1.0.0)
+        version: 0.5.2(@fideus-labs/ngff-zarr@0.12.3)(@fideus-labs/worker-pool@1.0.0)
       '@fideus-labs/ngff-zarr':
         specifier: ^0.12.0
-        version: 0.12.0
+        version: 0.12.3
       '@fideus-labs/worker-pool':
         specifier: ^1.0.0
         version: 1.0.0
@@ -89,7 +89,7 @@ importers:
         version: link:../../fidnii
       '@fideus-labs/ngff-zarr':
         specifier: ^0.12.0
-        version: 0.12.0
+        version: 0.12.3
       '@niivue/niivue':
         specifier: ^0.67.0
         version: 0.67.0
@@ -108,10 +108,10 @@ importers:
     dependencies:
       '@fideus-labs/fiff':
         specifier: ^0.5.2
-        version: 0.5.2(@fideus-labs/ngff-zarr@0.12.0)(@fideus-labs/worker-pool@1.0.0)
+        version: 0.5.2(@fideus-labs/ngff-zarr@0.12.3)(@fideus-labs/worker-pool@1.0.0)
       '@fideus-labs/ngff-zarr':
         specifier: ^0.12.0
-        version: 0.12.0
+        version: 0.12.3
       '@itk-wasm/downsample':
         specifier: ^1.8.1
         version: 1.8.1
@@ -136,7 +136,7 @@ importers:
     devDependencies:
       '@fideus-labs/fizarrita':
         specifier: ^1.4.0
-        version: 1.4.0(zarrita@0.6.1)
+        version: 1.4.1(zarrita@0.6.1)
       '@fideus-labs/worker-pool':
         specifier: ^1.0.0
         version: 1.0.0
@@ -535,13 +535,13 @@ packages:
       '@fideus-labs/worker-pool':
         optional: true
 
-  '@fideus-labs/fizarrita@1.4.0':
-    resolution: {integrity: sha512-6E1qVOQsc4hESlzLpuQpAbWnAYDgFZocatxxzr4CJh0ZUbOYRAKwpvQ30s22aEd5k9L1oeKXRJtCoumOIEfe4A==}
+  '@fideus-labs/fizarrita@1.4.1':
+    resolution: {integrity: sha512-71HTW4cTDeUnm2f3MU3352MMlpzUAFHhDmEajaASpUywVDe7RdY8ImjeXwRllKjvfPcukfz/aEmdPs67esSngA==}
     peerDependencies:
       zarrita: ^0.6.1
 
-  '@fideus-labs/ngff-zarr@0.12.0':
-    resolution: {integrity: sha512-XWWVeRRcfODam2RQ6hpbLASHsAi19ll5sySoneiHjH2YKiSBVgBdErYcs+JMhgc3KI5YrQxYFOdLNGwBlJ3/xg==}
+  '@fideus-labs/ngff-zarr@0.12.3':
+    resolution: {integrity: sha512-gtRh6wQ1fwsP3RFSgsl7QpxzsaDTlem8rVjDG/DF7ltb54i9k8KsxLGlEv+vZw1uxBsjqBgZ0rLHzn0n35PyEg==}
 
   '@fideus-labs/worker-pool@1.0.0':
     resolution: {integrity: sha512-Mwx8fFKKpTUcEtR7w45MQJ/RnZFUPBtefEvGTZGlZMAVSfD7W61rpB8ZdgS4V0CXfppwcb90BF7F/aANWvupnA==}
@@ -2624,23 +2624,23 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@fideus-labs/fiff@0.5.2(@fideus-labs/ngff-zarr@0.12.0)(@fideus-labs/worker-pool@1.0.0)':
+  '@fideus-labs/fiff@0.5.2(@fideus-labs/ngff-zarr@0.12.3)(@fideus-labs/worker-pool@1.0.0)':
     dependencies:
       geotiff: 3.0.3
       pako: 2.1.0
       zarrita: 0.6.1
     optionalDependencies:
-      '@fideus-labs/ngff-zarr': 0.12.0
+      '@fideus-labs/ngff-zarr': 0.12.3
       '@fideus-labs/worker-pool': 1.0.0
 
-  '@fideus-labs/fizarrita@1.4.0(zarrita@0.6.1)':
+  '@fideus-labs/fizarrita@1.4.1(zarrita@0.6.1)':
     dependencies:
       '@fideus-labs/worker-pool': 1.0.0
       zarrita: 0.6.1
 
-  '@fideus-labs/ngff-zarr@0.12.0':
+  '@fideus-labs/ngff-zarr@0.12.3':
     dependencies:
-      '@fideus-labs/fizarrita': 1.4.0(zarrita@0.6.1)
+      '@fideus-labs/fizarrita': 1.4.1(zarrita@0.6.1)
       '@fideus-labs/worker-pool': 1.0.0
       '@itk-wasm/downsample': 1.8.1
       '@zarrita/storage': 0.1.4


### PR DESCRIPTION
## Summary

Configure the Changesets release workflow to create GitHub Releases on publish and use npm trusted publishing (OIDC) instead of long-lived npm tokens.

## Changes

### `.github/workflows/release.yml`

- **`id-token: write` permission** — required for GitHub Actions to generate an OIDC token, which npm uses for trusted publishing authentication
- **`npm install -g npm@latest`** — npm trusted publishing requires npm CLI 11.5.1 or later; the GitHub-hosted runner ships an older version, so we upgrade before publishing
- **`createGithubReleases: true`** — explicitly enables GitHub Release creation after `pnpm changeset publish` succeeds (this is the default in `changesets/action`, but making it explicit documents the intent)
- **Removed `NPM_TOKEN` and `NODE_AUTH_TOKEN`** — no long-lived npm secret is needed; the npm CLI automatically detects the OIDC environment and exchanges a short-lived token directly with the registry

## Why

Trusted publishing (OIDC) is the recommended approach for CI/CD publishing to npm. It eliminates the need to create, store, rotate, or revoke long-lived npm tokens. Each publish uses a short-lived credential scoped to this specific workflow run that cannot be extracted or reused. Provenance attestation is also generated automatically when publishing from a public repository via OIDC — no `--provenance` flag required.

## Post-merge setup required

For the workflow to function, the following must be configured **once** on npmjs.com:

1. **Configure a Trusted Publisher** on the `@fideus-labs/fidnii` package settings page:
   - Go to [npmjs.com/package/@fideus-labs/fidnii](https://www.npmjs.com/package/@fideus-labs/fidnii) → Settings → Trusted Publisher
   - Select **GitHub Actions**
   - Fill in: org/user = `fideus-labs`, repository = `fidnii`, workflow filename = `release.yml`

2. **Workflow permissions** in GitHub repo settings:
   - Settings → Actions → General → "Read and write permissions"
   - Check "Allow GitHub Actions to create and approve pull requests"

No `NPM_TOKEN` secret is needed — that's the point.