### PR TITLE
fix(convert): add responsive single-column layout for small screens

### DIFF
--- a/examples/convert/index.html
+++ b/examples/convert/index.html
@@ -234,7 +234,7 @@
       .hidden {
         display: none;
       }
-      @media (max-width: 640px) {
+      @media (max-width: 768px) {
         .header {
           flex-direction: column;
           align-items: flex-start;
@@ -242,6 +242,21 @@
         }
         .github-star {
           align-self: flex-end;
+        }
+        body {
+          padding: 0.5rem;
+        }
+        .container {
+          grid-template-columns: 1fr;
+        }
+        .settings-grid {
+          grid-template-columns: 1fr;
+        }
+        #canvas-container {
+          aspect-ratio: 4 / 3;
+        }
+        #multiscales-card {
+          overflow-x: auto;
         }
       }
     </style>


### PR DESCRIPTION
Collapse the two-column grid to a single column at ≤768px so the
convert example is usable on phones and tablets in portrait mode.
Also stacks settings fields vertically, adjusts canvas aspect ratio,
and adds horizontal scroll on the multiscales table.
