### PR TITLE
feat: add TIFF loading support via @fideus-labs/fiff

### DIFF
--- a/.changeset/warm-tiffs-load.md
+++ b/.changeset/warm-tiffs-load.md
@@ -1,0 +1,5 @@
+---
+"@fideus-labs/fidnii": minor
+---
+
+Add TIFF loading support via `fromTiff()` helper and `@fideus-labs/fiff`

--- a/examples/convert/package.json
+++ b/examples/convert/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@awesome.me/webawesome": "^3.1.0",
     "@fideus-labs/fidnii": "workspace:*",
-    "@fideus-labs/ngff-zarr": "^0.9.0",
+    "@fideus-labs/ngff-zarr": "^0.10.0",
     "@itk-wasm/image-io": "^1.6.0",
     "@niivue/niivue": "^0.67.0",
     "itk-wasm": "1.0.0-b.196"

--- a/examples/getting-started/package.json
+++ b/examples/getting-started/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@fideus-labs/fidnii": "workspace:*",
-    "@fideus-labs/ngff-zarr": "^0.9.0",
+    "@fideus-labs/ngff-zarr": "^0.10.0",
     "@niivue/niivue": "^0.67.0"
   },
   "devDependencies": {

--- a/fidnii/package.json
+++ b/fidnii/package.json
@@ -23,7 +23,8 @@
     "test:ui": "playwright test --ui"
   },
   "dependencies": {
-    "@fideus-labs/ngff-zarr": "^0.9.0",
+    "@fideus-labs/fiff": "^0.3.2",
+    "@fideus-labs/ngff-zarr": "^0.10.0",
     "@itk-wasm/downsample": "^1.8.1",
     "lru-cache": "^11.1.0",
     "@niivue/niivue": "^0.67.0",

--- a/fidnii/src/fromTiff.ts
+++ b/fidnii/src/fromTiff.ts
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+/**
+ * Load TIFF files (OME-TIFF, pyramidal, plain) and produce a
+ * {@link Multiscales} object ready for {@link OMEZarrNVImage.create}.
+ *
+ * Uses {@link https://github.com/fideus-labs/fiff | @fideus-labs/fiff}
+ * to present TIFFs as zarrita-compatible stores, then delegates to
+ * {@link fromNgffZarr} for OME-Zarr metadata parsing.
+ */
+
+import type { TiffStoreOptions } from "@fideus-labs/fiff"
+import { TiffStore } from "@fideus-labs/fiff"
+import type { Multiscales } from "@fideus-labs/ngff-zarr"
+import type { FromNgffZarrOptions } from "@fideus-labs/ngff-zarr/browser"
+import { fromNgffZarr } from "@fideus-labs/ngff-zarr/browser"
+import type { Readable } from "zarrita"
+
+/** Options for {@link fromTiff}. */
+export interface FromTiffOptions {
+  /** Options forwarded to {@link TiffStore} (e.g. IFD offsets, HTTP headers). */
+  tiff?: TiffStoreOptions
+  /** Options forwarded to {@link fromNgffZarr} (e.g. validate, cache). */
+  ngffZarr?: Omit<FromNgffZarrOptions, "version">
+}
+
+/**
+ * Load a TIFF file and return a {@link Multiscales} object ready for
+ * {@link OMEZarrNVImage.create}.
+ *
+ * Supports OME-TIFF, pyramidal TIFF (SubIFDs / legacy / COG), and
+ * plain single-image TIFFs. Both local (Blob/ArrayBuffer) and
+ * remote (URL with HTTP range requests) sources are supported.
+ *
+ * @param source - A URL string, Blob/File, ArrayBuffer, or
+ *   pre-built {@link TiffStore}.
+ * @param options - Optional {@link FromTiffOptions}.
+ * @returns A {@link Multiscales} object for use with
+ *   {@link OMEZarrNVImage.create}.
+ * @throws If the source cannot be opened as a TIFF or if the
+ *   synthesized OME-Zarr metadata is invalid.
+ *
+ * @example
+ * ```typescript
+ * // From a remote URL
+ * const ms = await fromTiff("https://example.com/image.ome.tif")
+ * const image = await OMEZarrNVImage.create({
+ *   multiscales: ms,
+ *   niivue: nv,
+ * })
+ *
+ * // From a File input
+ * const file = inputElement.files[0]
+ * const ms = await fromTiff(file)
+ * ```
+ */
+export async function fromTiff(
+  source: string | Blob | ArrayBuffer | TiffStore,
+  options: FromTiffOptions = {},
+): Promise<Multiscales> {
+  let store: TiffStore
+  if (source instanceof TiffStore) {
+    store = source
+  } else if (typeof source === "string") {
+    store = await TiffStore.fromUrl(source, options.tiff)
+  } else if (source instanceof Blob) {
+    store = await TiffStore.fromBlob(source, options.tiff)
+  } else if (source instanceof ArrayBuffer) {
+    store = await TiffStore.fromArrayBuffer(source, options.tiff)
+  } else {
+    throw new Error(
+      "[fidnii] fromTiff: source must be a URL string, Blob, " +
+        "ArrayBuffer, or TiffStore",
+    )
+  }
+
+  // TiffStore implements zarrita's Readable interface structurally
+  // (its get() method accepts string keys including the leading "/"
+  // that zarrita uses for AbsolutePath). Since fromNgffZarr (v0.10+)
+  // accepts zarr.Readable directly, we only need a type assertion.
+  //
+  // TiffStore always produces OME-Zarr v0.5 metadata.
+  return fromNgffZarr(store as unknown as Readable, {
+    version: "0.5",
+    ...options.ngffZarr,
+  })
+}

--- a/fidnii/src/index.ts
+++ b/fidnii/src/index.ts
@@ -34,6 +34,8 @@
  * ```
  */
 
+export type { TiffStoreOptions } from "@fideus-labs/fiff"
+export { TiffStore } from "@fideus-labs/fiff"
 // Re-export Methods enum so consumers can check isLabelImage or compare method values
 export { Methods } from "@fideus-labs/ngff-zarr"
 // Worker pool lifecycle (re-exported from ngff-zarr)
@@ -72,6 +74,9 @@ export type {
 } from "./events.js"
 // Event system (browser-native EventTarget API)
 export { OMEZarrNVImageEvent } from "./events.js"
+export type { FromTiffOptions } from "./fromTiff.js"
+// TIFF support (via @fideus-labs/fiff)
+export { fromTiff } from "./fromTiff.js"
 // RGB normalization utilities
 export type { ChannelWindow } from "./normalize.js"
 export { computeChannelMinMax, normalizeToUint8 } from "./normalize.js"

--- a/fidnii/tests/tiff-loading.spec.ts
+++ b/fidnii/tests/tiff-loading.spec.ts
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: Copyright (c) Fideus Labs LLC
+// SPDX-License-Identifier: MIT
+
+import { expect, test } from "@playwright/test"
+
+test.describe("TIFF Loading", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/")
+    // Wait for the base page to load (ensures NiiVue is ready)
+    await expect(page.locator("#gl")).toBeVisible()
+    // Wait for test-page main.ts module to execute and expose fidnii on window
+    await page.waitForFunction(() => (window as any).fidnii !== undefined, {
+      timeout: 30000,
+    })
+  })
+
+  test("fromTiff is exported and exposed on window", async ({ page }) => {
+    const hasFromTiff = await page.evaluate(() => {
+      return typeof (window as any).fidnii.fromTiff === "function"
+    })
+    expect(hasFromTiff).toBe(true)
+  })
+
+  test("TiffStore is exported and exposed on window", async ({ page }) => {
+    const hasTiffStore = await page.evaluate(() => {
+      return typeof (window as any).fidnii.TiffStore === "function"
+    })
+    expect(hasTiffStore).toBe(true)
+  })
+
+  test("fromTiff loads an in-memory TIFF ArrayBuffer", async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const { fromTiff, buildTiff, makeImageTags } = (window as any).fidnii
+
+      // Create a 32x32 uint8 grayscale test image
+      const width = 32
+      const height = 32
+      const strip = new Uint8Array(width * height)
+      for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+          strip[y * width + x] = (x + y) % 256
+        }
+      }
+
+      // sampleFormat=1 (uint), bitsPerSample=8
+      const tags = makeImageTags(width, height, 8, 1)
+      const buffer = await buildTiff([{ tags, tiles: [strip] }])
+
+      // Load via fromTiff
+      const multiscales = await fromTiff(buffer)
+
+      return {
+        numImages: multiscales.images.length,
+        hasMetadata: multiscales.metadata !== undefined,
+        firstImageDims: multiscales.images[0].dims,
+        firstImageShape: multiscales.images[0].data.shape,
+      }
+    })
+
+    expect(result.numImages).toBeGreaterThanOrEqual(1)
+    expect(result.hasMetadata).toBe(true)
+    expect(result.firstImageDims).toContain("y")
+    expect(result.firstImageDims).toContain("x")
+    // 32x32 image
+    expect(result.firstImageShape).toContain(32)
+  })
+
+  test("fromTiff loads a Blob", async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const { fromTiff, buildTiff, makeImageTags } = (window as any).fidnii
+
+      const width = 16
+      const height = 16
+      const strip = new Uint8Array(width * height)
+      const tags = makeImageTags(width, height, 8, 1)
+      const buffer = await buildTiff([{ tags, tiles: [strip] }])
+
+      // Convert to Blob and load
+      const blob = new Blob([buffer], { type: "image/tiff" })
+      const multiscales = await fromTiff(blob)
+
+      return {
+        numImages: multiscales.images.length,
+        firstImageShape: multiscales.images[0].data.shape,
+      }
+    })
+
+    expect(result.numImages).toBeGreaterThanOrEqual(1)
+    expect(result.firstImageShape).toContain(16)
+  })
+
+  test("fromTiff with ArrayBuffer produces correct pixel data", async ({
+    page,
+  }) => {
+    const result = await page.evaluate(async () => {
+      const { fromTiff, buildTiff, makeImageTags } = (window as any).fidnii
+
+      const width = 32
+      const height = 32
+      const strip = new Uint8Array(width * height)
+      for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+          strip[y * width + x] = (x + y) % 256
+        }
+      }
+      const tags = makeImageTags(width, height, 8, 1)
+      const buffer = await buildTiff([{ tags, tiles: [strip] }])
+
+      const multiscales = await fromTiff(buffer)
+      const image = multiscales.images[0]
+
+      // Read pixel data through the zarr array
+      const chunk = await image.data.getChunk([0, 0])
+      const data = chunk.data as Uint8Array
+
+      return {
+        dtype: image.data.dtype,
+        firstPixel: data[0],
+        secondPixel: data[1],
+        dataLength: data.length,
+      }
+    })
+
+    expect(result.dtype).toBe("uint8")
+    // Gradient pattern: (0+0)%256=0, (1+0)%256=1
+    expect(result.firstPixel).toBe(0)
+    expect(result.secondPixel).toBe(1)
+    expect(result.dataLength).toBeGreaterThan(0)
+  })
+
+  test("fromTiff produces valid Multiscales for OMEZarrNVImage", async ({
+    page,
+  }) => {
+    // This is the key integration test: verify that fromTiff produces
+    // a Multiscales object that OMEZarrNVImage.create() can accept.
+    const result = await page.evaluate(async () => {
+      const { fromTiff, buildTiff, makeImageTags } = (window as any).fidnii
+
+      // Create a test image
+      const width = 64
+      const height = 64
+      const strip = new Uint8Array(width * height)
+      for (let i = 0; i < strip.length; i++) {
+        strip[i] = i % 256
+      }
+      const tags = makeImageTags(width, height, 8, 1)
+      const buffer = await buildTiff([{ tags, tiles: [strip] }])
+
+      const multiscales = await fromTiff(buffer)
+
+      // Verify the multiscales has the right structure
+      const metadata = multiscales.metadata
+      const axes = metadata.axes
+      const datasets = metadata.datasets
+
+      return {
+        numImages: multiscales.images.length,
+        axisNames: axes.map((a: { name: string }) => a.name),
+        numDatasets: datasets.length,
+        datasetPath: datasets[0].path,
+        hasCoordTransforms: datasets[0].coordinateTransformations !== undefined,
+        imageShape: multiscales.images[0].data.shape,
+        imageDtype: multiscales.images[0].data.dtype,
+      }
+    })
+
+    expect(result.numImages).toBeGreaterThanOrEqual(1)
+    expect(result.axisNames).toContain("y")
+    expect(result.axisNames).toContain("x")
+    expect(result.numDatasets).toBeGreaterThanOrEqual(1)
+    expect(result.datasetPath).toBe("0")
+    expect(result.hasCoordTransforms).toBe(true)
+    expect(result.imageShape).toContain(64)
+    expect(result.imageDtype).toBe("uint8")
+  })
+
+  test("fromTiff rejects invalid source type", async ({ page }) => {
+    const threw = await page.evaluate(async () => {
+      const { fromTiff } = (window as any).fidnii
+      try {
+        await fromTiff(42)
+        return false
+      } catch {
+        return true
+      }
+    })
+    expect(threw).toBe(true)
+  })
+})

--- a/fidnii/vite.config.ts
+++ b/fidnii/vite.config.ts
@@ -55,6 +55,7 @@ export default defineConfig({
     // inlines fizarrita's code and the relative worker URL resolves to the
     // wrong location (.vite/deps/ instead of fizarrita's dist/).
     exclude: [
+      "@fideus-labs/fiff",
       "@fideus-labs/fizarrita",
       "@fideus-labs/ngff-zarr",
       "@fideus-labs/ngff-zarr/browser",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "pnpm": {
     "overrides": {
-      "@fideus-labs/ngff-zarr": "^0.9.0",
+      "@fideus-labs/fiff": "^0.3.2",
       "zarrita": "^0.6.1",
       "@fideus-labs/fizarrita": "^1.3.0",
       "@fideus-labs/worker-pool": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@fideus-labs/ngff-zarr': ^0.9.0
+  '@fideus-labs/fiff': ^0.3.2
   zarrita: ^0.6.1
   '@fideus-labs/fizarrita': ^1.3.0
   '@fideus-labs/worker-pool': ^1.0.0
@@ -51,8 +51,8 @@ importers:
         specifier: workspace:*
         version: link:../../fidnii
       '@fideus-labs/ngff-zarr':
-        specifier: ^0.9.0
-        version: 0.9.0
+        specifier: ^0.10.0
+        version: 0.10.0
       '@itk-wasm/image-io':
         specifier: ^1.6.0
         version: 1.6.0
@@ -76,8 +76,8 @@ importers:
         specifier: workspace:*
         version: link:../../fidnii
       '@fideus-labs/ngff-zarr':
-        specifier: ^0.9.0
-        version: 0.9.0
+        specifier: ^0.10.0
+        version: 0.10.0
       '@niivue/niivue':
         specifier: ^0.67.0
         version: 0.67.0
@@ -94,9 +94,12 @@ importers:
 
   fidnii:
     dependencies:
+      '@fideus-labs/fiff':
+        specifier: ^0.3.2
+        version: 0.3.2(@fideus-labs/ngff-zarr@0.10.0)
       '@fideus-labs/ngff-zarr':
-        specifier: ^0.9.0
-        version: 0.9.0
+        specifier: ^0.10.0
+        version: 0.10.0
       '@itk-wasm/downsample':
         specifier: ^1.8.1
         version: 1.8.1
@@ -509,13 +512,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@fideus-labs/fiff@0.3.2':
+    resolution: {integrity: sha512-Ci+AJ5sar0FZkXSakRfW26vRV2rvc3o26ZXUh2AT21TkeaYqhhgiAhBpKMVsMIPe9ToVk5iSRO/maW0iSxg3TA==}
+    peerDependencies:
+      '@fideus-labs/ngff-zarr': ^0.10.0
+    peerDependenciesMeta:
+      '@fideus-labs/ngff-zarr':
+        optional: true
+
   '@fideus-labs/fizarrita@1.3.0':
     resolution: {integrity: sha512-jjczNtv9GKqJupT1ACxFvjmAnOvpDCk/6+Wia/aIuzw/JRcNH+rhK0arNYLIrqGEhv3q7+irE2IPTzAJleSOKw==}
     peerDependencies:
       zarrita: ^0.6.1
 
-  '@fideus-labs/ngff-zarr@0.9.0':
-    resolution: {integrity: sha512-p87JLa0HeORDrlqXO98eRSAD1QBssF9kvCcmLz3vWf5wNCyHUaG5BztKPAbwdbdOdUsnUsBLNVanDWq9G/VQ9w==}
+  '@fideus-labs/ngff-zarr@0.10.0':
+    resolution: {integrity: sha512-mVVw/xnYeuGZekVkP9zhISoJwPj7YA1d2bM4eHjVAWG0NlmS6vv6j4b0kBLKRBOGe6qbtGuyZBY038XiN8J48w==}
 
   '@fideus-labs/worker-pool@1.0.0':
     resolution: {integrity: sha512-Mwx8fFKKpTUcEtR7w45MQJ/RnZFUPBtefEvGTZGlZMAVSfD7W61rpB8ZdgS4V0CXfppwcb90BF7F/aANWvupnA==}
@@ -619,6 +630,9 @@ packages:
 
   '@perma/map@1.0.3':
     resolution: {integrity: sha512-Bf5njk0fnJGTFE2ETntq0N1oJ6YdCPIpTDn3R3KYZJQdeYSOCNL7mBrFlGnbqav8YQhJA/p81pvHINX9vAtHkQ==}
+
+  '@petamoriken/float16@3.9.3':
+    resolution: {integrity: sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==}
 
   '@playwright/test@1.58.2':
     resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
@@ -1241,6 +1255,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  geotiff@3.0.3:
+    resolution: {integrity: sha512-yRoDQDYxWYiB421p0cbxJvdy79OlQW+rxDI9GDbIUeWCAh6YAZ0vlTKF448EAiEuuUpBsNaegd2flavF0p+kvw==}
+    engines: {node: '>=10.19'}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -1535,6 +1553,9 @@ packages:
     resolution: {integrity: sha512-+vS+yywGQW6CN1J1hbGkez//6ixGHIQqfxDN/d3JDm531w9GfGt2lAWTDfZTw/CEl80XsN0raFcnEraR3ldw9g==}
     hasBin: true
 
+  lerc@3.0.0:
+    resolution: {integrity: sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -1716,9 +1737,15 @@ packages:
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
+  pako@2.1.0:
+    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-headers@2.0.6:
+    resolution: {integrity: sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==}
 
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
@@ -1817,6 +1844,10 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-lru@6.1.2:
+    resolution: {integrity: sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==}
+    engines: {node: '>=12'}
 
   rabin-rs@2.1.0:
     resolution: {integrity: sha512-5y72gAXPzIBsAMHcpxZP8eMDuDT98qMP1BqSDHRbHkJJXEgWIN1lA47LxUqzsK6jknOJtgfkQr9v+7qMlFDm6g==}
@@ -2068,6 +2099,9 @@ packages:
   wasm-feature-detect@1.8.0:
     resolution: {integrity: sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==}
 
+  web-worker@1.5.0:
+    resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -2089,6 +2123,9 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xml-utils@1.10.2:
+    resolution: {integrity: sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -2120,6 +2157,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zstddec@0.2.0:
+    resolution: {integrity: sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==}
 
 snapshots:
 
@@ -2535,12 +2575,20 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
+  '@fideus-labs/fiff@0.3.2(@fideus-labs/ngff-zarr@0.10.0)':
+    dependencies:
+      geotiff: 3.0.3
+      pako: 2.1.0
+      zarrita: 0.6.1
+    optionalDependencies:
+      '@fideus-labs/ngff-zarr': 0.10.0
+
   '@fideus-labs/fizarrita@1.3.0(zarrita@0.6.1)':
     dependencies:
       '@fideus-labs/worker-pool': 1.0.0
       zarrita: 0.6.1
 
-  '@fideus-labs/ngff-zarr@0.9.0':
+  '@fideus-labs/ngff-zarr@0.10.0':
     dependencies:
       '@fideus-labs/fizarrita': 1.3.0(zarrita@0.6.1)
       '@fideus-labs/worker-pool': 1.0.0
@@ -2702,6 +2750,8 @@ snapshots:
     dependencies:
       '@multiformats/murmur3': 2.2.0
       murmurhash3js-revisited: 3.0.0
+
+  '@petamoriken/float16@3.9.3': {}
 
   '@playwright/test@1.58.2':
     dependencies:
@@ -3260,6 +3310,17 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  geotiff@3.0.3:
+    dependencies:
+      '@petamoriken/float16': 3.9.3
+      lerc: 3.0.0
+      pako: 2.1.0
+      parse-headers: 2.0.6
+      quick-lru: 6.1.2
+      web-worker: 1.5.0
+      xml-utils: 1.10.2
+      zstddec: 0.2.0
+
   get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
@@ -3578,6 +3639,8 @@ snapshots:
       lefthook-windows-arm64: 2.1.0
       lefthook-windows-x64: 2.1.0
 
+  lerc@3.0.0: {}
+
   lines-and-columns@1.2.4: {}
 
   lit-element@4.2.2:
@@ -3719,9 +3782,13 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
+  pako@2.1.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-headers@2.0.6: {}
 
   parse-json@5.2.0:
     dependencies:
@@ -3806,6 +3873,8 @@ snapshots:
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  quick-lru@6.1.2: {}
 
   rabin-rs@2.1.0: {}
 
@@ -4059,6 +4128,8 @@ snapshots:
 
   wasm-feature-detect@1.8.0: {}
 
+  web-worker@1.5.0: {}
+
   webidl-conversions@3.0.1: {}
 
   whatwg-url@5.0.0:
@@ -4087,6 +4158,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  xml-utils@1.10.2: {}
 
   xtend@4.0.2: {}
 
@@ -4119,3 +4192,5 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.6: {}
+
+  zstddec@0.2.0: {}


### PR DESCRIPTION
Add fromTiff() helper that accepts URL, Blob, ArrayBuffer, or TiffStore
sources and produces a Multiscales object for OMEZarrNVImage.create().
Uses fiff's TiffStore as a zarrita-compatible Readable store passed to
fromNgffZarr (v0.10.0+, which now accepts zarr.Readable directly).

- Create fidnii/src/fromTiff.ts with FromTiffOptions interface
- Re-export fromTiff, TiffStore, TiffStoreOptions from public API
- Add ?tiff=<url> support to test-page for manual testing
- Add 7 Playwright e2e tests covering ArrayBuffer, Blob, export checks,
  pixel data verification, Multiscales structure, and error handling
- Bump @fideus-labs/ngff-zarr ^0.8.0 -> ^0.10.0 (zarr.Readable support)
- Bump @fideus-labs/fizarrita ^1.2.0 -> ^1.3.0 (createCacheKey export)
- Add @fideus-labs/fiff as dependency with local pnpm override
- Exclude @fideus-labs/fiff from Vite pre-bundling
