### PR TITLE
fix(ci): add build step before test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,8 @@ jobs:
         if: runner.os != 'Linux'
         run: pnpm exec playwright install chromium
 
+      - run: pnpm build
+
       - run: pnpm test
 
       - name: Upload Playwright report


### PR DESCRIPTION
The test job runs on a separate runner from the build job and its
artifacts aren't transferred, so fidnii/dist/ doesn't exist when
tests try to resolve the workspace package. Run pnpm build before
pnpm test to fix this.
