### PR TITLE
feat(convert): add per-chunk progress bar for OMERO computation and OZX packaging

### DIFF
--- a/examples/convert/index.html
+++ b/examples/convert/index.html
@@ -353,6 +353,21 @@
               style="margin: 0.5rem 0 0 0; font-size: 0.875rem"
             >
             </p>
+            <div id="chunk-progress-container" style="display: none">
+              <wa-progress-bar
+                id="chunk-progress-bar"
+                value="0"
+                style="margin-top: 0.75rem; --height: 0.5rem"
+              ></wa-progress-bar>
+              <p
+                id="chunk-progress-text"
+                style="
+                  margin: 0.25rem 0 0 0;
+                  font-size: 0.8125rem;
+                  color: var(--wa-color-text-quiet);
+                "
+              ></p>
+            </div>
           </wa-card>
         </div>
 


### PR DESCRIPTION
Leverage the onProgress callback added in @fideus-labs/ngff-zarr v0.11.0
to display a secondary progress bar with detailed chunk-level feedback
during the two WorkerPool-based stages of conversion:

- OMERO computation: shows 'OMERO computation: 15 / 42 chunks'
- OZX packaging: shows 'OZX packaging: 8 / 120 chunks'

The secondary bar appears beneath the main progress bar with smaller
height and quieter text styling, and resets between conversions.
