### PR TITLE
fix: disable anatomical orientation markers from niivue rendering

### DIFF
--- a/.changeset/ready-pigs-prove.md
+++ b/.changeset/ready-pigs-prove.md
@@ -1,0 +1,5 @@
+---
+"@fideus-labs/fidnii": patch
+---
+
+Disable orientation markers in niivue

--- a/examples/convert/main.ts
+++ b/examples/convert/main.ts
@@ -137,6 +137,8 @@ function initNiivue(): void {
     show3Dcrosshair: false,
     crosshairWidth: 0,
     backColor: [0, 0, 0, 1],
+    isOrientCube: false,
+    isOrientationTextVisible: false,
   })
   nv.attachToCanvas(canvas)
 }

--- a/examples/getting-started/main.ts
+++ b/examples/getting-started/main.ts
@@ -17,7 +17,11 @@ async function main() {
   const canvas = document.getElementById("gl") as HTMLCanvasElement
 
   // Initialize NiiVue
-  const nv = new Niivue({ backColor: [0, 0, 0, 1] })
+  const nv = new Niivue({
+    backColor: [0, 0, 0, 1],
+    isOrientCube: false,
+    isOrientationTextVisible: false,
+  })
   await nv.attachToCanvas(canvas)
   nv.setSliceType(nv.sliceTypeRender)
 

--- a/fidnii/test-page/main.ts
+++ b/fidnii/test-page/main.ts
@@ -402,12 +402,21 @@ async function main() {
   const canvas2 = document.getElementById("gl2") as HTMLCanvasElement
 
   // Create primary NV instance (3D render mode)
-  const nv = new Niivue({ backColor: [0, 0, 0, 1] })
+  const nv = new Niivue({
+    backColor: [0, 0, 0, 1],
+    isOrientCube: false,
+    isOrientationTextVisible: false,
+  })
   await nv.attachToCanvas(canvas)
   nv.setSliceType(nv.sliceTypeRender)
 
   // Create secondary NV instance (2D slice mode, no crosshairs)
-  const nv2 = new Niivue({ backColor: [0, 0, 0, 1], crosshairWidth: 0 })
+  const nv2 = new Niivue({
+    backColor: [0, 0, 0, 1],
+    crosshairWidth: 0,
+    isOrientCube: false,
+    isOrientationTextVisible: false,
+  })
   await nv2.attachToCanvas(canvas2)
   nv2.setSliceType(nv2.sliceTypeAxial)
 


### PR DESCRIPTION
Set isOrientCube and isOrientationTextVisible to false on all Niivue
instances to remove the 3D orientation cube and L/R/A/P/S/I text labels.
