### PR TITLE
fix: add COOP/COEP preview headers and require fizarrita 1.4.0

### DIFF
--- a/examples/convert/vite.config.ts
+++ b/examples/convert/vite.config.ts
@@ -21,6 +21,12 @@ export default defineConfig({
       "Cross-Origin-Embedder-Policy": "require-corp",
     },
   },
+  preview: {
+    headers: {
+      "Cross-Origin-Opener-Policy": "same-origin",
+      "Cross-Origin-Embedder-Policy": "require-corp",
+    },
+  },
   optimizeDeps: {
     exclude: [
       "@awesome.me/webawesome",

--- a/examples/getting-started/vite.config.ts
+++ b/examples/getting-started/vite.config.ts
@@ -20,6 +20,12 @@ export default defineConfig({
       "Cross-Origin-Embedder-Policy": "require-corp",
     },
   },
+  preview: {
+    headers: {
+      "Cross-Origin-Opener-Policy": "same-origin",
+      "Cross-Origin-Embedder-Policy": "require-corp",
+    },
+  },
   optimizeDeps: {
     exclude: ["@fideus-labs/ngff-zarr", "@fideus-labs/fizarrita"],
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "overrides": {
       "@fideus-labs/fiff": "^0.3.2",
       "zarrita": "^0.6.1",
-      "@fideus-labs/fizarrita": "^1.3.0",
+      "@fideus-labs/fizarrita": "^1.4.0",
       "@fideus-labs/worker-pool": "^1.0.0",
       "@playwright/test": "^1.58.2",
       "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   '@fideus-labs/fiff': ^0.3.2
   zarrita: ^0.6.1
-  '@fideus-labs/fizarrita': ^1.3.0
+  '@fideus-labs/fizarrita': ^1.4.0
   '@fideus-labs/worker-pool': ^1.0.0
   '@playwright/test': ^1.58.2
   typescript: ^5.9.3
@@ -126,8 +126,8 @@ importers:
         version: 3.25.76
     devDependencies:
       '@fideus-labs/fizarrita':
-        specifier: ^1.3.0
-        version: 1.3.0(zarrita@0.6.1)
+        specifier: ^1.4.0
+        version: 1.4.0(zarrita@0.6.1)
       '@fideus-labs/worker-pool':
         specifier: ^1.0.0
         version: 1.0.0
@@ -523,8 +523,8 @@ packages:
       '@fideus-labs/ngff-zarr':
         optional: true
 
-  '@fideus-labs/fizarrita@1.3.0':
-    resolution: {integrity: sha512-jjczNtv9GKqJupT1ACxFvjmAnOvpDCk/6+Wia/aIuzw/JRcNH+rhK0arNYLIrqGEhv3q7+irE2IPTzAJleSOKw==}
+  '@fideus-labs/fizarrita@1.4.0':
+    resolution: {integrity: sha512-6E1qVOQsc4hESlzLpuQpAbWnAYDgFZocatxxzr4CJh0ZUbOYRAKwpvQ30s22aEd5k9L1oeKXRJtCoumOIEfe4A==}
     peerDependencies:
       zarrita: ^0.6.1
 
@@ -2586,14 +2586,14 @@ snapshots:
     optionalDependencies:
       '@fideus-labs/ngff-zarr': 0.11.0
 
-  '@fideus-labs/fizarrita@1.3.0(zarrita@0.6.1)':
+  '@fideus-labs/fizarrita@1.4.0(zarrita@0.6.1)':
     dependencies:
       '@fideus-labs/worker-pool': 1.0.0
       zarrita: 0.6.1
 
   '@fideus-labs/ngff-zarr@0.11.0':
     dependencies:
-      '@fideus-labs/fizarrita': 1.3.0(zarrita@0.6.1)
+      '@fideus-labs/fizarrita': 1.4.0(zarrita@0.6.1)
       '@fideus-labs/worker-pool': 1.0.0
       '@itk-wasm/downsample': 1.8.1
       '@zarrita/storage': 0.1.4


### PR DESCRIPTION
The vite preview server was missing Cross-Origin-Opener-Policy and
Cross-Origin-Embedder-Policy headers, preventing SharedArrayBuffer
(required by codec workers) from being available in production preview.

Add preview.headers to both examples/convert and examples/getting-started
vite configs, matching the existing server.headers.

Bump the fizarrita override to ^1.4.0 which fixes Vite production builds
by using a bundler-recognisable worker creation pattern.
