### PR TITLE
docs(getting-started): build with pnpm

### DIFF
--- a/examples/getting-started/README.md
+++ b/examples/getting-started/README.md
@@ -6,8 +6,9 @@ A minimal example showing how to load and display an OME-Zarr image using
 ## Quick Start
 
 ```bash
-npm install
-npm run dev
+# From the repository root
+pnpm install
+pnpm --filter @fideus-labs/fidnii-getting-started dev
 ```
 
 Open http://localhost:5173 in your browser.


### PR DESCRIPTION
We switched back to pnpm to facilitate testing/deployment.
