### PR TITLE
fix(ci): remove registry-url to unblock OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
         with:
           node-version: 24
           cache: pnpm
-          registry-url: https://registry.npmjs.org
 
       - name: Upgrade npm (required for trusted publishing)
         run: npm install -g npm@11.10.0


### PR DESCRIPTION
## Summary

Remove `registry-url` from the `actions/setup-node` step in the release workflow to fix the `E404 / Access token expired or revoked` error when publishing via npm trusted publishing (OIDC).

## Problem

The previous release attempt ([run #22238760213](https://github.com/fideus-labs/fidnii/actions/runs/22238760213/job/64336869460)) failed despite OIDC being correctly detected (`No NPM_TOKEN found, but OIDC is available - using npm trusted publishing`). The root cause: `actions/setup-node` with `registry-url` writes an `.npmrc` at `/home/runner/work/_temp/.npmrc` containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` and sets `NPM_CONFIG_USERCONFIG` to point at it. This token-based `.npmrc` takes precedence over the OIDC token exchange, causing npm to attempt authentication with an empty/invalid `NODE_AUTH_TOKEN` instead of performing the OIDC flow.

## Change

Remove `registry-url: https://registry.npmjs.org` from `actions/setup-node`. The npm CLI defaults to `registry.npmjs.org` already, and this project has no private npm dependencies that would require a pre-configured auth token for `npm install`. Without the `registry-url` option, `setup-node` won't generate the interfering `.npmrc`, allowing the npm CLI to perform OIDC token exchange during `npm publish`.