### PR TITLE
fix(ci): fix npm trusted publishing by splitting publish into separate step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
           version: pnpm changeset version
           title: "chore: version packages"
           commit: "chore: version packages"
-          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -52,3 +51,12 @@ jobs:
         run: pnpm changeset publish
         env:
           NPM_CONFIG_PROVENANCE: true
+
+      - name: Create GitHub releases
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        run: |
+          for tag in $(git tag --points-at HEAD); do
+            gh release create "$tag" --generate-notes || true
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fix the `ENEEDAUTH` error during npm publishing by removing the `registry-url` from `setup-node` and moving the publish command out of the `changesets/action` into a standalone workflow step, ensuring OIDC environment variables are available to `npm publish`.

## Problem

Publishing via npm trusted publishing (OIDC) has failed across multiple attempts:

1. **E404 / Access token expired** ([run #22238760213](https://github.com/fideus-labs/fidnii/actions/runs/22238760213)) — `actions/setup-node` with `registry-url` writes an `.npmrc` containing a `NODE_AUTH_TOKEN` placeholder that takes precedence over OIDC token exchange.
2. **ENEEDAUTH** ([run #22359201759](https://github.com/fideus-labs/fidnii/actions/runs/22359201759)) — After removing `registry-url`, npm finds no auth at all because the `changesets/action` runs `pnpm changeset publish` inside its own Node.js subprocess, which does not propagate the OIDC environment variables (`ACTIONS_ID_TOKEN_REQUEST_URL`, `ACTIONS_ID_TOKEN_REQUEST_TOKEN`) needed for the npm CLI to perform the OIDC token exchange.

## Changes

1. **Remove `registry-url` from `actions/setup-node`** — Prevents `setup-node` from generating an `.npmrc` with a stale token placeholder that overrides OIDC. The npm CLI defaults to `registry.npmjs.org` already.

2. **Split publish out of `changesets/action` into its own step** — Instead of passing `publish: pnpm changeset publish` to the action (which runs it in a subprocess without OIDC env vars), the action now only handles versioning and PR creation. A separate `Publish to npm` step runs `pnpm changeset publish` directly in the workflow context where OIDC env vars are guaranteed to be present. It is gated on `steps.changesets.outputs.hasChangesets == 'false'` (no pending changesets = versions are bumped and ready to publish).

3. **Remove `NPM_TOKEN: ''`** — No longer needed since publish no longer runs inside the `changesets/action`.