### PR TITLE
feat: upgrade niivue to 0.68.1 and migrate to browser-native events

### DIFF
--- a/.changeset/upgrade-niivue-events.md
+++ b/.changeset/upgrade-niivue-events.md
@@ -1,0 +1,18 @@
+---
+"@fideus-labs/fidnii": minor
+---
+
+Upgrade niivue to 0.68.1 and migrate to browser-native events
+
+Replace the fragile save-and-chain callback pattern (`nv.onClipPlaneChange`,
+`nv.onOptsChange`, `nv.onLocationChange`, `nv.onMouseUp`, `nv.onZoom3DChange`)
+with niivue's new `EventTarget`-based event system (`addEventListener`).
+
+This eliminates the need to save/restore previous callback handlers, supports
+multiple listeners per event, and uses `AbortController` for clean teardown.
+
+- `onClipPlaneChange` → `addEventListener("clipPlaneChange", ...)`
+- `onOptsChange` (sliceType filter) → `addEventListener("sliceTypeChange", ...)`
+- `onLocationChange` → `addEventListener("locationChange", ...)`
+- `onMouseUp` → `addEventListener("mouseUp", ...)`
+- `onZoom3DChange` → `addEventListener("zoom3DChange", ...)`

--- a/examples/convert/package.json
+++ b/examples/convert/package.json
@@ -16,7 +16,7 @@
     "@fideus-labs/worker-pool": "^1.0.0",
     "@itk-wasm/downsample": "^1.8.1",
     "@itk-wasm/image-io": "^1.6.0",
-    "@niivue/niivue": "^0.67.0",
+    "@niivue/niivue": "^0.68.1",
     "itk-wasm": "1.0.0-b.196"
   },
   "devDependencies": {

--- a/examples/getting-started/package.json
+++ b/examples/getting-started/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@fideus-labs/fidnii": "workspace:*",
     "@fideus-labs/ngff-zarr": "^0.12.3",
-    "@niivue/niivue": "^0.67.0"
+    "@niivue/niivue": "^0.68.1"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/fidnii/package.json
+++ b/fidnii/package.json
@@ -26,7 +26,7 @@
     "@fideus-labs/fiff": "^0.5.2",
     "@fideus-labs/ngff-zarr": "^0.12.3",
     "@itk-wasm/downsample": "^1.8.1",
-    "@niivue/niivue": "^0.67.0",
+    "@niivue/niivue": "^0.68.1",
     "gl-matrix": "^3.4.4",
     "lru-cache": "^11.1.0",
     "nifti-reader-js": "^0.8.0",
@@ -43,7 +43,7 @@
     "vite": "^5.4.21"
   },
   "peerDependencies": {
-    "@niivue/niivue": ">=0.67.0"
+    "@niivue/niivue": ">=0.68.1"
   },
   "keywords": [
     "niivue",

--- a/fidnii/src/OMEZarrNVImage.ts
+++ b/fidnii/src/OMEZarrNVImage.ts
@@ -187,8 +187,8 @@ export class OMEZarrNVImage extends NVImage {
   /** Current buffer bounds in world space (may differ from full volume when clipped) */
   private _currentBufferBounds: VolumeBounds
 
-  /** Previous clip plane change handler (to restore later) */
-  private previousOnClipPlaneChange?: (clipPlane: number[]) => void
+  /** AbortController for the clip plane event listener on the primary NV */
+  private _clipPlaneAbortController?: AbortController
 
   /** Debounce delay for clip plane updates (ms) */
   private readonly clipPlaneDebounceMs: number
@@ -469,16 +469,16 @@ export class OMEZarrNVImage extends NVImage {
   static async create(options: OMEZarrNVImageOptions): Promise<OMEZarrNVImage> {
     const image = new OMEZarrNVImage(options)
 
-    // Store and replace the clip plane change handler
-    image.previousOnClipPlaneChange = image.niivue.onClipPlaneChange
-    image.niivue.onClipPlaneChange = (clipPlane: number[]) => {
-      // Call original handler if it exists
-      if (image.previousOnClipPlaneChange) {
-        image.previousOnClipPlaneChange(clipPlane)
-      }
-      // Handle clip plane change
-      image.onNiivueClipPlaneChange(clipPlane)
-    }
+    // Listen for clip plane changes via the browser-native event API
+    const clipPlaneController = new AbortController()
+    image._clipPlaneAbortController = clipPlaneController
+    image.niivue.addEventListener(
+      "clipPlaneChange",
+      (e) => {
+        image.onNiivueClipPlaneChange(e.detail.clipPlane)
+      },
+      { signal: clipPlaneController.signal },
+    )
 
     // Auto-attach the primary NV instance for slice type / location tracking
     image.attachNiivue(image.niivue)
@@ -1663,37 +1663,41 @@ export class OMEZarrNVImage extends NVImage {
   }
 
   /**
-   * Hook viewport events (onMouseUp, onZoom3DChange, wheel) on a NV instance.
+   * Hook viewport events (mouseUp, zoom3DChange, wheel) on a NV instance.
+   * All listeners share a single AbortController so they can be torn down
+   * together via {@link _unhookViewportEvents}.
    */
   private _hookViewportEvents(nv: Niivue, state: AttachedNiivueState): void {
-    // Save and chain onMouseUp (fires at end of any mouse/touch interaction)
-    state.previousOnMouseUp = nv.onMouseUp as (data: unknown) => void
-    nv.onMouseUp = (data: unknown) => {
-      if (state.previousOnMouseUp) {
-        state.previousOnMouseUp(data)
-      }
-      this._handleViewportInteractionEnd(nv)
-    }
-
-    // Save and chain onZoom3DChange (fires when volScaleMultiplier changes)
-    state.previousOnZoom3DChange = nv.onZoom3DChange
-    nv.onZoom3DChange = (zoom: number) => {
-      if (state.previousOnZoom3DChange) {
-        state.previousOnZoom3DChange(zoom)
-      }
-      this._handleViewportInteractionEnd(nv)
-    }
-
-    // Add wheel event listener on the canvas for scroll-wheel zoom detection
     const controller = new AbortController()
     state.viewportAbortController = controller
+    const signal = controller.signal
+
+    // Detect end of mouse/touch interaction
+    nv.addEventListener(
+      "mouseUp",
+      () => {
+        this._handleViewportInteractionEnd(nv)
+      },
+      { signal },
+    )
+
+    // Detect 3D zoom level changes
+    nv.addEventListener(
+      "zoom3DChange",
+      () => {
+        this._handleViewportInteractionEnd(nv)
+      },
+      { signal },
+    )
+
+    // Detect scroll-wheel zoom on the canvas
     if (nv.canvas) {
       nv.canvas.addEventListener(
         "wheel",
         () => {
           this._handleViewportInteractionEnd(nv)
         },
-        { signal: controller.signal, passive: true },
+        { signal, passive: true },
       )
     }
   }
@@ -1701,20 +1705,7 @@ export class OMEZarrNVImage extends NVImage {
   /**
    * Unhook viewport events from a NV instance.
    */
-  private _unhookViewportEvents(nv: Niivue, state: AttachedNiivueState): void {
-    // Restore onMouseUp
-    if (state.previousOnMouseUp !== undefined) {
-      nv.onMouseUp = state.previousOnMouseUp as typeof nv.onMouseUp
-      state.previousOnMouseUp = undefined
-    }
-
-    // Restore onZoom3DChange
-    if (state.previousOnZoom3DChange !== undefined) {
-      nv.onZoom3DChange = state.previousOnZoom3DChange
-      state.previousOnZoom3DChange = undefined
-    }
-
-    // Remove wheel event listener
+  private _unhookViewportEvents(_nv: Niivue, state: AttachedNiivueState): void {
     if (state.viewportAbortController) {
       state.viewportAbortController.abort()
       state.viewportAbortController = undefined
@@ -2131,9 +2122,10 @@ export class OMEZarrNVImage extends NVImage {
   /**
    * Attach a Niivue instance for slice-type-aware rendering.
    *
-   * The image auto-detects the NV's current slice type and hooks into
-   * `onOptsChange` to track mode changes and `onLocationChange` to track
-   * crosshair/slice position changes.
+   * The image auto-detects the NV's current slice type and uses
+   * `addEventListener('sliceTypeChange', ...)` to track mode changes and
+   * `addEventListener('locationChange', ...)` to track crosshair/slice
+   * position changes via Niivue's browser-native EventTarget API.
    *
    * When the NV is in a 2D slice mode (Axial, Coronal, Sagittal), the image
    * loads a slab (one chunk thick in the orthogonal direction) at the current
@@ -2144,37 +2136,32 @@ export class OMEZarrNVImage extends NVImage {
   attachNiivue(nv: Niivue): void {
     if (this._attachedNiivues.has(nv)) return // Already attached
 
+    const eventAbortController = new AbortController()
     const state: AttachedNiivueState = {
       nv,
       currentSliceType: this._detectSliceType(nv),
-      previousOnLocationChange: nv.onLocationChange,
-      previousOnOptsChange:
-        nv.onOptsChange as AttachedNiivueState["previousOnOptsChange"],
+      eventAbortController,
     }
 
-    // Hook onOptsChange to detect slice type changes
-    nv.onOptsChange = (
-      propertyName: string,
-      newValue: unknown,
-      oldValue: unknown,
-    ) => {
-      // Chain to previous handler
-      if (state.previousOnOptsChange) {
-        state.previousOnOptsChange(propertyName, newValue, oldValue)
-      }
-      if (propertyName === "sliceType") {
-        this._handleSliceTypeChange(nv, newValue as SLICE_TYPE)
-      }
-    }
+    const signal = eventAbortController.signal
 
-    // Hook onLocationChange to detect slice position changes
-    nv.onLocationChange = (location: unknown) => {
-      // Chain to previous handler
-      if (state.previousOnLocationChange) {
-        state.previousOnLocationChange(location)
-      }
-      this._handleLocationChange(nv, location)
-    }
+    // Listen for slice type changes via the browser-native event API
+    nv.addEventListener(
+      "sliceTypeChange",
+      (e) => {
+        this._handleSliceTypeChange(nv, e.detail.sliceType)
+      },
+      { signal },
+    )
+
+    // Listen for crosshair/slice position changes
+    nv.addEventListener(
+      "locationChange",
+      (e) => {
+        this._handleLocationChange(nv, e.detail)
+      },
+      { signal },
+    )
 
     this._attachedNiivues.set(nv, state)
 
@@ -2194,7 +2181,9 @@ export class OMEZarrNVImage extends NVImage {
   }
 
   /**
-   * Detach a Niivue instance, restoring its original callbacks.
+   * Detach a Niivue instance, removing all event listeners registered by this
+   * image (viewport, zoom-override, slice-type, location, and clip-plane
+   * listeners are all torn down via their respective `AbortController`s).
    *
    * @param nv - The Niivue instance to detach
    */
@@ -2208,10 +2197,14 @@ export class OMEZarrNVImage extends NVImage {
     // Unhook 3D zoom override
     this._unhookZoomOverride(nv, state)
 
-    // Restore original callbacks
-    nv.onLocationChange = state.previousOnLocationChange ?? (() => {})
-    nv.onOptsChange = (state.previousOnOptsChange ??
-      (() => {})) as typeof nv.onOptsChange
+    // Remove niivue event listeners (sliceTypeChange, locationChange)
+    state.eventAbortController.abort()
+
+    // If detaching the primary NV, also remove the clip plane listener
+    if (nv === this.niivue && this._clipPlaneAbortController) {
+      this._clipPlaneAbortController.abort()
+      this._clipPlaneAbortController = undefined
+    }
 
     this._attachedNiivues.delete(nv)
   }

--- a/fidnii/src/types.ts
+++ b/fidnii/src/types.ts
@@ -296,18 +296,8 @@ export interface AttachedNiivueState {
   nv: Niivue
   /** The current slice type of this NV instance */
   currentSliceType: SLICE_TYPE
-  /** Previous onLocationChange callback (to chain) */
-  previousOnLocationChange?: (location: unknown) => void
-  /** Previous onOptsChange callback (to chain) */
-  previousOnOptsChange?: (
-    propertyName: string,
-    newValue: unknown,
-    oldValue: unknown,
-  ) => void
-  /** Previous onMouseUp callback (to chain, for viewport-aware mode) */
-  previousOnMouseUp?: (data: unknown) => void
-  /** Previous onZoom3DChange callback (to chain, for viewport-aware mode) */
-  previousOnZoom3DChange?: (zoom: number) => void
+  /** AbortController for niivue addEventListener listeners (sliceTypeChange, locationChange) */
+  eventAbortController: AbortController
   /** AbortController for viewport-aware event listeners (wheel, etc.) */
   viewportAbortController?: AbortController
   /** AbortController for the 3D zoom override wheel listener */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0
       '@niivue/niivue':
-        specifier: ^0.67.0
-        version: 0.67.0
+        specifier: ^0.68.1
+        version: 0.68.1
       itk-wasm:
         specifier: 1.0.0-b.196
         version: 1.0.0-b.196
@@ -92,8 +92,8 @@ importers:
         specifier: ^0.13.0
         version: 0.13.0
       '@niivue/niivue':
-        specifier: ^0.67.0
-        version: 0.67.0
+        specifier: ^0.68.1
+        version: 0.68.1
     devDependencies:
       '@playwright/test':
         specifier: ^1.58.2
@@ -117,8 +117,8 @@ importers:
         specifier: ^1.8.1
         version: 1.8.1
       '@niivue/niivue':
-        specifier: ^0.67.0
-        version: 0.67.0
+        specifier: ^0.68.1
+        version: 0.68.1
       gl-matrix:
         specifier: ^3.4.4
         version: 3.4.4
@@ -629,8 +629,8 @@ packages:
   '@multiformats/sha3@3.0.2':
     resolution: {integrity: sha512-fBxODTXa1sOWYB9q6GSFe2HYSVwMEdnPa7c7FgNhr/rMFQ2HGtwmRppTm317HSpGSTUkoTvyKQDNcteJEGU+bg==}
 
-  '@niivue/niivue@0.67.0':
-    resolution: {integrity: sha512-j08xdhKEkInUWpuIyJ5jborf++RmUa1TEOGzFh/fxTsXR+2fAlocY8guPaNzxh3N0XSTyDKcwKjbw8VZfV87Ew==}
+  '@niivue/niivue@0.68.1':
+    resolution: {integrity: sha512-uZ/4pJ6mGk8UY8DWOu+/cC/AOpPQW7W6kEhyOrEhuUDZW5+lPmmcnqU6ilipiR4iAcSA8r9KTXJm+p55iTyUgw==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2773,7 +2773,7 @@ snapshots:
       js-sha3: 0.9.3
       multiformats: 13.4.2
 
-  '@niivue/niivue@0.67.0':
+  '@niivue/niivue@0.68.1':
     dependencies:
       '@lukeed/uuid': 2.0.1
       '@ungap/structured-clone': 1.3.0


### PR DESCRIPTION
Replace the save-and-chain callback pattern (onClipPlaneChange,
onOptsChange, onLocationChange, onMouseUp, onZoom3DChange) with
niivue's new EventTarget-based event system (addEventListener).

Uses AbortController for clean listener teardown on detach. Switches
from the generic onOptsChange with a sliceType filter to the more
specific sliceTypeChange event.