### PR TITLE
fix: remove Red, Green, and Blue colormap options from convert example

### DIFF
--- a/examples/convert/index.html
+++ b/examples/convert/index.html
@@ -613,9 +613,6 @@
               <wa-option value="viridis">Viridis</wa-option>
               <wa-option value="plasma">Plasma</wa-option>
               <wa-option value="inferno">Inferno</wa-option>
-              <wa-option value="red">Red</wa-option>
-              <wa-option value="green">Green</wa-option>
-              <wa-option value="blue">Blue</wa-option>
             </wa-select>
             <wa-select
               id="slice-type"


### PR DESCRIPTION
## Summary

- Remove the "Red", "Green", and "Blue" single-channel colormap options from the convert example's colormap dropdown
- These colormaps are not useful for the typical medical/scientific imaging use case of the convert tool, which already offers perceptually uniform colormaps (Viridis, Plasma, Inferno) and standard options (Fast, Gray, Hot, Cool)

## Changes

Removed three `<wa-option>` entries (`red`, `green`, `blue`) from the `<wa-select id="colormap">` dropdown in `examples/convert/index.html`. No other files required changes — the colormap value is read dynamically from the select element at runtime.

Resolves THE-11