### PR TITLE
fix(convert): hide 3D-only preview controls for 2D images

### DIFF
--- a/examples/convert/main.ts
+++ b/examples/convert/main.ts
@@ -472,7 +472,11 @@ const updateChunkProgress: ChunkProgressCallback = (
 
 /** Show or hide the 3D-only preview controls. */
 function set3DControlsVisible(visible: boolean): void {
-  const controls = [opacitySlider, silhouetteSlider, sliceTypeGroup]
+  const controls: Element[] = [
+    opacitySlider,
+    silhouetteSlider,
+    sliceTypeGroup.closest("fieldset")!,
+  ]
   for (const el of controls) {
     el.classList.toggle("hidden", !visible)
   }


### PR DESCRIPTION
## Summary

When a 2D image is loaded in the convert example, the slice type selector, gradient opacity slider, and silhouette enhancement slider are now **hidden** instead of shown in a disabled (grayed-out) state. These controls only apply to 3D volumes, so displaying them for 2D inputs adds unnecessary visual clutter.

## Changes

- Renamed `set3DControlsEnabled()` to `set3DControlsVisible()` in `examples/convert/main.ts`
- Replaced the `disabled` attribute toggle with a `hidden` CSS class toggle, reusing the existing `.hidden { display: none; }` utility class from `index.html`
- Controls automatically reappear when a 3D volume is loaded

## Affected controls

| Control | 2D image | 3D volume |
|---|---|---|
| Slice Type selector | Hidden | Visible |
| Gradient Opacity slider | Hidden | Visible |
| Silhouette Enhancement slider | Hidden | Visible |
| Colormap selector | Unchanged (separate logic) | Unchanged |